### PR TITLE
fix(artifacts): Persist file extension

### DIFF
--- a/packages/deployment-server/src/deployment-artifacts/routes.ts
+++ b/packages/deployment-server/src/deployment-artifacts/routes.ts
@@ -6,13 +6,16 @@ import { pipeline } from 'stream/promises'
 import { validate } from '../util/validate'
 import multer from 'multer'
 import { CreateArtifactResponseBody } from '.'
+import { extname, join } from 'path'
+
+const destination = 'uploads/'
 
 export default function deploymentArtifactsRoutes (router: Router): void {
   const upload = multer({
     storage: multer.diskStorage({
-      destination: 'uploads/',
-      filename: (_req, _file, cb) => {
-        cb(null, randomUUID())
+      destination,
+      filename: (_req, file, cb) => {
+        cb(null, randomUUID() + extname(file.originalname))
       }
     })
   })
@@ -45,7 +48,7 @@ export default function deploymentArtifactsRoutes (router: Router): void {
   )
 
   const params = Type.Object({
-    artifactId: Type.String({ format: 'uuid' })
+    artifactId: Type.String()
   }, { additionalProperties: false })
 
   router.get(
@@ -54,9 +57,11 @@ export default function deploymentArtifactsRoutes (router: Router): void {
     async (req, res, next) => {
       try {
         const filename = req.params.artifactId
+        const filePath = join(destination, filename)
 
-        // validation rejects escape attempts
-        const filePath = `uploads/${filename}`
+        if (filePath.indexOf(destination) !== 0) {
+          return res.sendStatus(404)
+        }
 
         return await pipeline(createReadStream(filePath), res)
       } catch (e) {

--- a/packages/deployment-server/test/artifact.spec.ts
+++ b/packages/deployment-server/test/artifact.spec.ts
@@ -37,7 +37,7 @@ const filePath = join(dirname(fileURLToPath(import.meta.url)), './fixtures/artif
 const buffer = Buffer.from(await readFile(filePath))
 const arraybuffer = Uint8Array.from(buffer)
 const formData = new FormData()
-const file = new File([arraybuffer], 'artifact', { type: 'text/plain' })
+const file = new File([arraybuffer], 'artifact.txt', { type: 'text/plain' })
 let download: string
 
 test('Can upload', async (t) => {
@@ -51,7 +51,7 @@ test('Can upload', async (t) => {
 
   const json = await response.json() as { artifactUri: string}
 
-  t.match(json.artifactUri, /^http:\/\/.*\/deployment-artifacts\/[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}/)
+  t.match(json.artifactUri, /^http:\/\/.*\/deployment-artifacts\/[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}.txt/)
 
   download = json.artifactUri
 })
@@ -66,4 +66,15 @@ test('Can download', async (t) => {
 
   t.equal(body.size, file.size, 'Size is correct')
   t.equal(body.arrayBuffer, file.arrayBuffer, 'Content is correct')
+})
+
+test('prevents traversal', async (t) => {
+  const response = await fetch(`${baseUrl}/deployment-artifacts/` + encodeURIComponent('../package.json'), {
+    method: 'GET'
+  })
+
+  const body = await response.json()
+
+  t.notOk(response.ok, 'Response is ok')
+  t.same(body, { message: 'Not Found' })
 })


### PR DESCRIPTION
See tests: We now persist the file extension and should allow access to subfolders, while preventing path traversal out of the base directory.