### PR TITLE
feat(deployment-server): Query for deployable device-types

### DIFF
--- a/packages/deployment-server/package.json
+++ b/packages/deployment-server/package.json
@@ -31,7 +31,7 @@
     "seed": "yarn nts prisma/seed.ts"
   },
   "dependencies": {
-    "@prisma/client": "^3.5.0",
+    "@prisma/client": "^3.6.0",
     "@sinclair/typebox": "^0.21.2",
     "close-with-grace": "^1.1.0",
     "cors": "^2.8.5",
@@ -40,7 +40,6 @@
     "express-json-validator-middleware": "^2.2.1",
     "multer": "^1.4.3",
     "pino-http": "^6.3.3",
-    "prisma": "^3.5.0",
     "statuses": "^2.0.1",
     "undici": "^4.10.1",
     "ws": "^8.3.0"
@@ -65,6 +64,7 @@
     "eslint-plugin-promise": "^5.1.1",
     "nodemon": "^2.0.15",
     "pino-pretty": "^7.2.0",
+    "prisma": "^3.6.0",
     "tap": "^15.1.1",
     "typescript": "^4.5.2"
   },

--- a/packages/deployment-server/src/util/app.ts
+++ b/packages/deployment-server/src/util/app.ts
@@ -39,6 +39,10 @@ export function createApp (db: PrismaClient): Application {
   deploymentRequestsRoutes(app)
   deploymentArtifactsRoutes(app)
 
+  app.use(function notFoundResponse (_req, res) {
+    res.sendStatus(404)
+  })
+
   app.use(errorHandler)
 
   return app

--- a/packages/deployment-server/src/util/logger.ts
+++ b/packages/deployment-server/src/util/logger.ts
@@ -1,5 +1,5 @@
 import { env } from 'node:process'
-import pino from 'pino-http'
+import pino, { HttpLogger } from 'pino-http'
 
 const devTransport = {
   target: 'pino-pretty',
@@ -13,6 +13,6 @@ export const pinoHttp = pino({
   level: env.NODE_ENV === 'test' ? 'fatal' : 'info'
 })
 
-export const logger = pinoHttp.logger
+export const logger: HttpLogger['logger'] = pinoHttp.logger
 
 export default logger

--- a/packages/deployment-server/src/util/validate.ts
+++ b/packages/deployment-server/src/util/validate.ts
@@ -2,7 +2,7 @@ import { Validator } from 'express-json-validator-middleware'
 import { RequestHandler } from 'express'
 
 export const validate = new Validator({
-  coerceTypes: true,
+  coerceTypes: 'array',
   useDefaults: 'empty'
 }).validate as <ResBody = never, Params = {}, ReqBody = never, Locals = never>(
   ...args: Parameters<Validator['validate']>

--- a/packages/deployment-server/test/connector.spec.ts
+++ b/packages/deployment-server/test/connector.spec.ts
@@ -49,7 +49,7 @@ test('Retrieves all connectors', async (t) => {
 
   const body = await response.json() as Connector[]
 
-  t.ok(body.filter(x => x.id === connector.id))
+  t.ok(body.some(x => x.id === connector.id))
 })
 
 // Test that adding a connector

--- a/yarn.lock
+++ b/yarn.lock
@@ -2176,22 +2176,22 @@
   dependencies:
     prop-types "^15.6.1"
 
-"@prisma/client@^3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-3.5.0.tgz#bb0c9c10fd9912209f5bfd01c1683094d8fa9a2d"
-  integrity sha512-LuaaisknLe9CCfJ1Rtqe9b9knvPgEEcC77OMmWdo3fSanxl5oTDxcH3IIhpULQQlJfZvDcaEXuXNU4dsNF+q1w==
+"@prisma/client@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-3.6.0.tgz#68a60cd4c73a369b11f72e173e86fd6789939293"
+  integrity sha512-ycSGY9EZGROtje0iCNsgC5Zqi/ttX2sO7BNMYaLsUMiTlf3F69ZPH+08pRo0hrDfkZzyimXYqeXJlaoYDH1w7A==
   dependencies:
-    "@prisma/engines-version" "3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e"
+    "@prisma/engines-version" "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727"
 
-"@prisma/engines-version@3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e":
-  version "3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e.tgz#254fdb80ae6db397ee1e638d12561f35d058e340"
-  integrity sha512-X16YmBmj7Omso4ZbkNBe6gPYlNcnwZMUPtXsguCkn+KoMqm3DJD9M4X31gx0Gf13Q44dY3SKPJZUk44/XUj/WA==
+"@prisma/engines-version@3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727":
+  version "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727.tgz#25aa447776849a774885866b998732b37ec4f4f5"
+  integrity sha512-vtoO2ys6mSfc8ONTWdcYztKN3GBU1tcKBj0aXObyjzSuGwHFcM/pEA0xF+n1W4/0TAJgfoPX2khNEit6g0jtNA==
 
-"@prisma/engines@3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e":
-  version "3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e.tgz#1873885836294060239f8a887452fd429dc03ae1"
-  integrity sha512-MqZUrxuLlIbjB3wu8LrRJOKcvR4k3dunKoI4Q2bPfAwLQY0XlpsLZ3TRVW1c32ooVk939p6iGNkaCUo63Et36g==
+"@prisma/engines@3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727":
+  version "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727.tgz#c68ede6aeffa9ef7743a32cfa6daf9172a4e15b3"
+  integrity sha512-dRClHS7DsTVchDKzeG72OaEyeDskCv91pnZ72Fftn0mp4BkUvX2LvWup65hCNzwwQm5IDd6A88APldKDnMiEMA==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -11439,12 +11439,12 @@ pretty-format@^26.0.0, pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
-prisma@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-3.5.0.tgz#3717368d75568b370869a5b588f688bd41a14130"
-  integrity sha512-WEYQ+H98O0yigG+lI0gfh4iyBChvnM6QTXPDtY9eFraLXAmyb6tf/T2mUdrUAU1AEvHLVzQA5A+RpONZlQozBg==
+prisma@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-3.6.0.tgz#99532abc02e045e58c6133a19771bdeb28cecdbe"
+  integrity sha512-6SqgHS/5Rq6HtHjsWsTxlj+ySamGyCLBUQfotc2lStOjPv52IQuDVpp58GieNqc9VnfuFyHUvTZw7aQB+G2fvQ==
   dependencies:
-    "@prisma/engines" "3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e"
+    "@prisma/engines" "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727"
 
 private@~0.1.5:
   version "0.1.8"


### PR DESCRIPTION
Adds a query parameter (`deployable`) that returns all the device types where at least one device is handling potential requests and the device is either available, deploying or running some code, therefore ensuring we can at least queue a deployment request.