### PR TITLE
fix(DeviceConnector): Artifact runtime timeout & monitor on device state

### DIFF
--- a/packages/device-connector/src/deployment-server/connection.ts
+++ b/packages/device-connector/src/deployment-server/connection.ts
@@ -8,7 +8,6 @@ import { Duplex } from 'stream'
 import { deployBinary, DeploymentData } from '../devices/deployment'
 import { MonitorData } from '../devices/monitoring'
 import { ConnectedDevices } from '../devices/store'
-import { DeviceStatus } from '../util/common'
 import { unregisterDevice } from '../devices/service'
 
 export interface ConnectorData {
@@ -124,11 +123,10 @@ export const openStream = async (): Promise<Duplex> => {
       try {
         const device = ConnectedDevices.get(data.device.id)
         if (command === 'start') {
-          if (device.status === DeviceStatus.AVAILABLE) {
-            await device.monitorOutput(5) // TODO: monitor currently set to 5sec for testing purposes
-          } else {
-            const monitoring = device.isMonitoring() ? DeviceStatus.RUNNING : device.status
-            logger.error(`Requested Device with id ${device.id} busy (${monitoring})`)
+          try {
+            await device.monitorOutput()
+          } catch (e) {
+            logger.error(e)
           }
         } else if (command === 'stop') {
           await device.stopMonitoring()


### PR DESCRIPTION
## Changes Proposed:
<!-- Describe the changes to the code and functionality with this PR -->

- Adds timeout for artifact runtimes
- Correct monitor behavior

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->

- Fixes issue where devices stay in running state forever
- Fixes issue with monitoring due to incorrect device state check

## How to Test PRs
1) First fetch the Pull-Request from the main repo, replacing `xx` with the ID of the PR:\
`git fetch git@github.com:eclipsesource/cdtcloud-deploymentserver.git pull/xx/head:pr_xx`
2) Checkout the Pull-Request, again replacing `xx` with the PR-ID:\
`git checkout pr_xx`
3) Perform the necessary tests for the PR