### PR TITLE
fix(DeviceConnector): Pipe monitor output into correct stream

### DIFF
--- a/packages/deployment-server/src/connectors/queue.ts
+++ b/packages/deployment-server/src/connectors/queue.ts
@@ -27,7 +27,7 @@ export const QueueManager = {
 
       const id = match[1]
 
-      if (this.queueMap.has(id) == null) {
+      if (!this.queueMap.has(id)) {
         return socket.destroy()
       }
 

--- a/packages/deployment-server/src/deployments/service.ts
+++ b/packages/deployment-server/src/deployments/service.ts
@@ -21,7 +21,7 @@ export function registerDeviceStreamRoutes (server: Server): void {
 
     const id: string = match[1]
 
-    if (openStreams.has(id) == null) {
+    if (!openStreams.has(id)) {
       return socket.destroy()
     }
 

--- a/packages/device-connector/src/arduino-cli/client.ts
+++ b/packages/device-connector/src/arduino-cli/client.ts
@@ -384,7 +384,12 @@ export class GRPCClient {
 
       stream.on('data', (data: MonitorResponse) => {
         if (data.rx_data != null) {
-          logger.debug(`Monitoring ${port.address}: ${data.rx_data.toString()}`)
+          const outData = data.rx_data.toString()
+          if (outData.match(/^\s*$/) != null) {
+            logger.trace(`Monitoring ${port.address} (Empty line): ${outData}`)
+          } else {
+            logger.debug(`Monitoring ${port.address}: ${outData}`)
+          }
         }
       })
 

--- a/packages/device-connector/src/deployment-server/connection.ts
+++ b/packages/device-connector/src/deployment-server/connection.ts
@@ -17,7 +17,7 @@ export interface ConnectorData {
 }
 
 export let connectorId: string
-const deployUrl = `${env.DEPLOY_IP ?? '127.0.0.1'}:${env.DEPLOY_PORT ?? '3001'}`
+export const deployUrl = `${env.DEPLOY_IP ?? '127.0.0.1'}:${env.DEPLOY_PORT ?? '3001'}`
 export const deployUri = `http${env.DEPLOY_SECURE === 'true' ? 's' : ''}://${deployUrl}/api`
 
 const readConnectorData = async (): Promise<ConnectorData> => {
@@ -78,7 +78,7 @@ const writeConnectorData = async (connectorData: ConnectorData): Promise<void> =
   })
 }
 
-export const openStream = async (): Promise<Duplex> => {
+export const openConnectorStream = async (): Promise<Duplex> => {
   let connectorData: ConnectorData | undefined
   if (fs.existsSync('.connection.data')) {
     connectorData = await readConnectorData()
@@ -92,7 +92,7 @@ export const openStream = async (): Promise<Duplex> => {
     } catch (e) {
       logger.error(e)
       await setTimeout(3000)
-      return await openStream()
+      return await openConnectorStream()
     }
     try {
       await writeConnectorData(connectorData)
@@ -117,7 +117,7 @@ export const openStream = async (): Promise<Duplex> => {
   socket.onclose = async (event: CloseEvent) => {
     logger.error(`Connection to Deployment-Server failed: ${event.reason}(${event.code}) - Trying to reconnect`)
     await setTimeout(3000)
-    return await openStream()
+    return await openConnectorStream()
   }
 
   socket.onmessage = async (message: MessageEvent) => {
@@ -170,4 +170,23 @@ export const openStream = async (): Promise<Duplex> => {
   })
 
   return duplex
+}
+
+export const openDeployStream = async (deploymentId: string): Promise<Duplex> => {
+  const uri = `ws${env.DEPLOY_SECURE === 'true' ? 's' : ''}://${deployUrl}/api/deployments/${deploymentId}/stream`
+  const socket = new WebSocket(uri)
+
+  socket.onopen = () => {
+    logger.debug(`Deployment-Stream ${deploymentId}: Opened - OK`)
+  }
+
+  socket.onerror = (error: ErrorEvent) => {
+    logger.error(`Deployment-Stream ${deploymentId}: Error - ${error.message}`)
+  }
+
+  socket.onclose = (event: CloseEvent) => {
+    logger.debug(`Deployment-Stream ${deploymentId}: Closed - ${event.reason}(${event.code})`)
+  }
+
+  return createWebSocketStream(socket)
 }

--- a/packages/device-connector/src/deviceConnector.ts
+++ b/packages/device-connector/src/deviceConnector.ts
@@ -1,6 +1,6 @@
 import { buildCli } from './arduino-cli/service'
 import { GRPCClient } from './arduino-cli/client'
-import { openStream } from './deployment-server/connection'
+import { openConnectorStream } from './deployment-server/connection'
 import { Signals } from 'close-with-grace'
 import { Duplex } from 'stream'
 import { logger } from './util/logger'
@@ -15,7 +15,7 @@ export interface DeviceConnector {
 
 export const createConnector = async (): Promise<DeviceConnector> => {
   arduinoClient = await buildCli()
-  deploymentSocket = await openStream()
+  deploymentSocket = await openConnectorStream()
 
   return { arduinoClient, deploymentSocket }
 }

--- a/packages/device-connector/src/devices/device.ts
+++ b/packages/device-connector/src/devices/device.ts
@@ -130,13 +130,6 @@ export class ConnectedDevice implements Device {
     // Update device status and notify server of status-change
     await this.updateStatus(DeviceStatus.DEPLOYING)
     this.#deployment = deployment
-    /* Questionable removal
-    try {
-      await setDeployRequest(deployment.id, DeployStatus.RUNNING)
-    } catch (e) {
-      logger.error(e)
-    }
-     */
 
     try {
       // Start uploading artifact
@@ -154,7 +147,7 @@ export class ConnectedDevice implements Device {
     // Update device status and notify server of status-change
     try {
       await this.updateStatus(DeviceStatus.RUNNING)
-      await setDeployRequest(deployment.id, DeployStatus.RUNNING) // Questionable
+      await setDeployRequest(deployment.id, DeployStatus.RUNNING)
     } catch (e) {
       logger.error(e)
     }
@@ -166,7 +159,7 @@ export class ConnectedDevice implements Device {
       if (this.isMonitoring()) {
         await this.stopMonitoring()
       }
-      await setDeployRequest(deployment.id, DeployStatus.SUCCESS) // Questionable
+      await setDeployRequest(deployment.id, DeployStatus.TERMINATED)
       await this.updateStatus(DeviceStatus.AVAILABLE)
     } catch (e) {
       logger.error(e)


### PR DESCRIPTION
## Changes Proposed:
<!-- Describe the changes to the code and functionality with this PR -->

- Send monitor output over dedicated deployment stream instead of common connector stream

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->

- Monitoring output sent through the wrong socket

## Tests Performed:
<!-- Describe any tests performed -->

- Deployed artifact, started monitoring and debugged output on the deployment server

## Known Issues and TODO List:
<!-- Is there anything else left to do after/in this PR? -->

- [ ] Monitoring requests don't work in certain cases

## How to Test PRs
1) First fetch the Pull-Request from the main repo, replacing `xx` with the ID of the PR:\
`git fetch git@github.com:eclipsesource/cdtcloud-deploymentserver.git pull/xx/head:pr_xx`
2) Checkout the Pull-Request, again replacing `xx` with the PR-ID:\
`git checkout pr_xx`
3) Perform the necessary tests for the PR