### PR TITLE
fix(DeviceConnector): Fix status not set to success & update type imports

### DIFF
--- a/packages/deployment-server/prisma/migrations/20220121173228_monitoring_status/migration.sql
+++ b/packages/deployment-server/prisma/migrations/20220121173228_monitoring_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "DeviceStatus" ADD VALUE 'MONITORING';

--- a/packages/deployment-server/prisma/schema.prisma
+++ b/packages/deployment-server/prisma/schema.prisma
@@ -38,6 +38,7 @@ enum DeviceStatus {
   AVAILABLE
   DEPLOYING
   RUNNING
+  MONITORING
 }
 
 model DeployRequest {

--- a/packages/deployment-server/src/devices/index.ts
+++ b/packages/deployment-server/src/devices/index.ts
@@ -1,0 +1,5 @@
+import { Connector, Device } from '@prisma/client'
+
+export type DeviceWithConnector = Device & { connector: Connector }
+
+export type { Device }

--- a/packages/deployment-server/src/devices/service.ts
+++ b/packages/deployment-server/src/devices/service.ts
@@ -1,11 +1,10 @@
 import prismaClient from '@prisma/client'
-import type { Device, Connector } from '@prisma/client'
+import type { Device } from '@prisma/client'
 import { db } from '../util/prisma'
+import { DeviceWithConnector } from './index'
 
 const MAX_QUEUE_SIZE = 3
 const { DeployStatus, DeviceStatus, Prisma } = prismaClient
-
-type DeviceWithConnector = Device & { connector: Connector }
 
 export async function getAvailableDevice (deviceType: string): Promise<DeviceWithConnector | null> {
   return await db.device.findFirst({

--- a/packages/deployment-server/src/index.ts
+++ b/packages/deployment-server/src/index.ts
@@ -26,5 +26,6 @@ try {
 export * from './connectors'
 export * from './deployment-artifacts'
 export * from './device-types'
+export * from './devices'
 export * from './deployments'
 export * from './dashboard'

--- a/packages/device-connector/src/deployment-server/service.ts
+++ b/packages/device-connector/src/deployment-server/service.ts
@@ -1,4 +1,4 @@
-import type { DeviceType, Device } from '@prisma/client'
+import type { DeviceType, Device } from 'deployment-server'
 import { DeployStatus, DeviceStatus } from '../util/common'
 import { fetch } from 'undici'
 import { connectorId, deployUri } from './connection'
@@ -53,6 +53,21 @@ export const setDeviceRequest = async (deviceId: string, status: keyof typeof De
     body: JSON.stringify({
       status: status
     })
+  })
+
+  if (!resp.ok) {
+    throw httpError(resp)
+  }
+
+  return await resp.json() as Device
+}
+
+export const getDeviceRequest = async (deviceId: string): Promise<Device> => {
+  const resp = await fetch(`${deployUri}/devices/${deviceId}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json'
+    }
   })
 
   if (!resp.ok) {

--- a/packages/device-connector/src/device-types/service.ts
+++ b/packages/device-connector/src/device-types/service.ts
@@ -1,4 +1,4 @@
-import type { DeviceType } from '@prisma/client'
+import type { DeviceType } from 'deployment-server'
 import { sendNewDeviceTypeRequest } from '../deployment-server/service'
 import { DeviceTypes } from './store'
 import { logger } from '../util/logger'

--- a/packages/device-connector/src/device-types/store.ts
+++ b/packages/device-connector/src/device-types/store.ts
@@ -1,4 +1,4 @@
-import type { DeviceType } from '@prisma/client'
+import type { DeviceType } from 'deployment-server'
 import { fetchAllDeviceTypes } from '../deployment-server/service'
 import { FQBN } from './service'
 import { logger } from '../util/logger'

--- a/packages/device-connector/src/devices/deployment.ts
+++ b/packages/device-connector/src/devices/deployment.ts
@@ -1,4 +1,4 @@
-import type { Device } from '@prisma/client'
+import type { Device } from 'deployment-server'
 import crypto from 'crypto'
 import { createWriteStream } from 'fs'
 import Path, { dirname, basename } from 'path'

--- a/packages/device-connector/src/devices/device.ts
+++ b/packages/device-connector/src/devices/device.ts
@@ -1,7 +1,7 @@
 import type { Port__Output as Port } from 'arduino-cli_proto_ts/common/cc/arduino/cli/commands/v1/Port'
-import type { Device, DeviceType } from '@prisma/client'
+import type { Device, DeviceType } from 'deployment-server'
 import { DeployStatus, DeviceStatus } from '../util/common'
-import { fetchDeviceType, setDeployRequest, setDeviceRequest } from '../deployment-server/service'
+import { fetchDeviceType, getDeviceRequest, setDeployRequest, setDeviceRequest } from '../deployment-server/service'
 import { DeviceMonitor } from './monitoring'
 import { FQBN } from '../device-types/service'
 import { DeviceTypes } from '../device-types/store'
@@ -55,16 +55,33 @@ export class ConnectedDevice implements Device {
   }
 
   async updateStatus (status: keyof typeof DeviceStatus): Promise<void> {
-    // Only set remote status back to available if there are no deployments queued
-    if (status !== DeviceStatus.AVAILABLE || this.deployQueue.length === 0) {
+    let remoteStatus = null
+
+    // Update remotely if deploying
+    if (status === DeviceStatus.DEPLOYING || status === DeviceStatus.MONITORING) {
       try {
-        await setDeviceRequest(this.id, status)
+        // Set remote status back to available when queue is finished
+        const resp = await setDeviceRequest(this.id, status)
+        remoteStatus = resp.status
       } catch (e) {
         logger.error(e)
       }
     }
 
-    // Only set remote status and don't execute further steps if status is already set locally
+    // Only check if remote status is unknown
+    if (remoteStatus != null) {
+      try {
+        // Check remote status against local status
+        const resp = await getDeviceRequest(this.id)
+        remoteStatus = resp.status
+        if (remoteStatus !== status) {
+          logger.warn(`Requested status ${status} does not equal remote status ${remoteStatus} - Continuing anyway`)
+        }
+      } catch (e) {
+        logger.error(e)
+      }
+    }
+
     if (this.status === status) {
       return
     }
@@ -77,7 +94,14 @@ export class ConnectedDevice implements Device {
     if (this.status === DeviceStatus.AVAILABLE) {
       const next = this.deployQueue.pop()
       if (next != null) {
-        await this.deploy(next)
+        this.deploy(next).catch(logger.error)
+      } else {
+        try {
+          // Set remote status back to available when queue is finished
+          await setDeviceRequest(this.id, status)
+        } catch (e) {
+          logger.error(e)
+        }
       }
     }
   }
@@ -91,7 +115,7 @@ export class ConnectedDevice implements Device {
       this.#deviceMonitor = new DeviceMonitor(this.port)
     }
 
-    await this.updateStatus(DeviceStatus.UNAVAILABLE)
+    await this.updateStatus(DeviceStatus.MONITORING)
     await this.#deviceMonitor.start(this.#deployment.id, sec)
   }
 
@@ -124,7 +148,7 @@ export class ConnectedDevice implements Device {
     return false
   }
 
-  async deploy (deployment: Deployment, runtimeMS: number = 120000): Promise<void> {
+  async deploy (deployment: Deployment, runtimeMS: number = 30 * 1000): Promise<void> {
     const fqbn = await this.getFQBN()
 
     // Update device status and notify server of status-change
@@ -153,7 +177,7 @@ export class ConnectedDevice implements Device {
     }
 
     // Run code only for a set amount of time. Set device back to available after.
-    // Default: 2min
+    // Default: 30sec
     await setTimeout(runtimeMS)
     try {
       if (this.#deployment.id === deployment.id) {
@@ -162,6 +186,11 @@ export class ConnectedDevice implements Device {
         }
         await this.updateStatus(DeviceStatus.AVAILABLE)
       }
+    } catch (e) {
+      logger.error(e)
+    }
+
+    try {
       await setDeployRequest(deployment.id, DeployStatus.SUCCESS)
     } catch (e) {
       logger.error(e)

--- a/packages/device-connector/src/devices/monitoring.ts
+++ b/packages/device-connector/src/devices/monitoring.ts
@@ -1,5 +1,5 @@
 import type { Port__Output as Port } from 'arduino-cli_proto_ts/common/cc/arduino/cli/commands/v1/Port'
-import type { Device } from '@prisma/client'
+import type { Device } from 'deployment-server'
 import { ClientDuplexStream } from '@grpc/grpc-js'
 import { Duplex, pipeline, Transform } from 'stream'
 import { ConnectedDevices } from './store'

--- a/packages/device-connector/src/devices/service.ts
+++ b/packages/device-connector/src/devices/service.ts
@@ -1,7 +1,7 @@
 import type {
   DetectedPort__Output as DetectedPort
 } from 'arduino-cli_proto_ts/common/cc/arduino/cli/commands/v1/DetectedPort'
-import type { Device } from '@prisma/client'
+import type { Device } from 'deployment-server'
 import { deleteDeviceRequest, sendNewDeviceRequest } from '../deployment-server/service'
 import { FQBN, getDeviceTypeId } from '../device-types/service'
 import { ConnectedDevice } from './device'

--- a/packages/device-connector/src/util/common.ts
+++ b/packages/device-connector/src/util/common.ts
@@ -2,7 +2,8 @@ export const DeviceStatus = {
   UNAVAILABLE: 'UNAVAILABLE',
   AVAILABLE: 'AVAILABLE',
   DEPLOYING: 'DEPLOYING',
-  RUNNING: 'RUNNING'
+  RUNNING: 'RUNNING',
+  MONITORING: 'MONITORING'
 } as const
 
 export const DeployStatus = {


### PR DESCRIPTION
## Changes Proposed:
<!-- Describe the changes to the code and functionality with this PR -->

- Properly export type Device from deployment-server
- Add status monitoring to DeviceStatus
- Fix incorrect deployment status

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->

- Fixes an issue where the deployment isn't set to successful in certain cases

## How to Test PRs
1) First fetch the Pull-Request from the main repo, replacing `xx` with the ID of the PR:\
`git fetch git@github.com:eclipsesource/cdtcloud-deploymentserver.git pull/xx/head:pr_xx`
2) Checkout the Pull-Request, again replacing `xx` with the PR-ID:\
`git checkout pr_xx`
3) Perform the necessary tests for the PR