### PR TITLE
fix(DeviceConnector): Don't delete device on remove & Suppress nodejs warnings

### DIFF
--- a/packages/device-connector/package.json
+++ b/packages/device-connector/package.json
@@ -7,8 +7,8 @@
   "license": "EPL-2.0",
   "type": "module",
   "scripts": {
-    "dev": "nodemon -x node --loader esbuild-node-loader -r dotenv/config src/index.ts dotenv_config_path=.env.dev",
-    "start": "node --loader esbuild-node-loader -r dotenv/config src/index.ts",
+    "dev": "nodemon -x node --loader esbuild-node-loader --no-warnings -r dotenv/config src/index.ts dotenv_config_path=.env.dev",
+    "start": "node --loader esbuild-node-loader --no-warnings -r dotenv/config src/index.ts",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "test": "tap",
     "test:dev": "tap -w",

--- a/packages/device-connector/src/devices/service.ts
+++ b/packages/device-connector/src/devices/service.ts
@@ -2,11 +2,12 @@ import type {
   DetectedPort__Output as DetectedPort
 } from 'arduino-cli_proto_ts/common/cc/arduino/cli/commands/v1/DetectedPort'
 import type { Device } from '@prisma/client'
-import { deleteDeviceRequest, sendNewDeviceRequest } from '../deployment-server/service'
+import { deleteDeviceRequest, sendNewDeviceRequest, setDeviceRequest } from '../deployment-server/service'
 import { FQBN, getDeviceTypeId } from '../device-types/service'
 import { ConnectedDevice } from './device'
 import { ConnectedDevices } from './store'
 import { logger } from '../util/logger'
+import { DeviceStatus } from '../util/common'
 
 export const registerNewDevice = async (fqbn: FQBN, name: string): Promise<Device> => {
   const typeId = await getDeviceTypeId(fqbn, name)
@@ -58,5 +59,9 @@ export const addDevice = async (detectedPort: DetectedPort): Promise<void> => {
 export const removeDevice = async (device: ConnectedDevice): Promise<void> => {
   ConnectedDevices.remove(device)
 
-  await unregisterDevice(device.id)
+  try {
+    await setDeviceRequest(device.id, DeviceStatus.UNAVAILABLE)
+  } catch (e) {
+    logger.error(e)
+  }
 }


### PR DESCRIPTION
## Changes Proposed:
<!-- Describe the changes to the code and functionality with this PR -->

- Devices now get set to unavailable instead of being deleted
- Nodejs warnings are being suppressed

## How to Test PRs
1) First fetch the Pull-Request from the main repo, replacing `xx` with the ID of the PR:\
`git fetch git@github.com:eclipsesource/cdtcloud-deploymentserver.git pull/xx/head:pr_xx`
2) Checkout the Pull-Request, again replacing `xx` with the PR-ID:\
`git checkout pr_xx`
3) Perform the necessary tests for the PR