### PR TITLE
fix(deployment-server): Headers for GCS hosted artifacts

### DIFF
--- a/packages/deployment-server-ui/src/components/Dashboard/RecentDeploymentItem.tsx
+++ b/packages/deployment-server-ui/src/components/Dashboard/RecentDeploymentItem.tsx
@@ -1,5 +1,4 @@
 import { Button, Col, List, Modal, Row, Tooltip, Typography } from 'antd'
-import { CSSTransition } from 'react-transition-group'
 import { DeployStatus, DeviceType, Device } from 'deployment-server'
 import React, { useEffect, useState } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -15,14 +14,14 @@ const { Item } = List
 const { Meta } = Item
 
 interface Props {
-  id: string,
-  status: DeployStatus,
+  id: string
+  status: DeployStatus
   device: Device & {
     type: DeviceType
-  },
-  artifactUrl: string | null,
-  details?: boolean,
-  created?: Date,
+  }
+  artifactUrl: string | null
+  details?: boolean
+  created?: Date
   updated?: Date
 }
 
@@ -59,102 +58,98 @@ export const RecentDeploymentItem = (props: Props) => {
   }, [])
 
   return (
-    <CSSTransition key={props.id} timeout={750} classNames={'deployment'}>
-      <Item
-        actions={[
-          <Button
-            type={'primary'}
-            icon={<FontAwesomeIcon icon={'terminal'} style={{ marginRight: '0.5em' }}/>}
-            disabled={props.status !== 'RUNNING'}
-            onClick={() => setMonitorOpen(true)}
-          >
-            Monitor
-          </Button>,
-          <Button
-            type="primary"
-            href={`/types/${props.device.deviceTypeId}`}
-            icon={<FontAwesomeIcon icon={'microchip'} style={{marginRight: '0.5em'}}/>}
-          >
-            Inspect Device
-          </Button>,
-          <Tooltip title={artifactUnavailable ? 'Artifact unavailable for download' : ''}>
-            <Button
-              type={'primary'}
-              disabled={artifactUnavailable}
-              icon={<FontAwesomeIcon icon={'download'} style={{ marginRight: '0.5em' }}/>}
-              href={artifactUrl}
-              download={fileName}
-            >
-              Artifact
-            </Button>
-          </Tooltip>
-        ]}
-      >
-        <Modal
-          title={`${props.device.type.name} Monitor`}
-          centered
-          visible={monitorOpen}
-          className={styles.modal}
-          width={'70%'}
-          footer={
-            <Button key={'close'} type={'primary'} onClick={() => setMonitorOpen(false)}>
-              Close
-            </Button>
-          }
-          onCancel={() => setMonitorOpen(false)}
+    <Item
+      actions={[
+        <Button
+          type='primary'
+          icon={<FontAwesomeIcon icon='terminal' style={{ marginRight: '0.5em' }} />}
+          disabled={props.status !== 'RUNNING'}
+          onClick={() => setMonitorOpen(true)}
         >
-          <MonitoringTerminal deploymentId={props.id} deployStatus={props.status} deviceName={props.device.type.name}/>
-        </Modal>
-        <Meta
-          style={{ flex: 'auto' }}
-          avatar={
-            <StatusTag status={props.status} addIcon/>
+          Monitor
+        </Button>,
+        <Button
+          type='primary'
+          href={`/types/${props.device.deviceTypeId}`}
+          icon={<FontAwesomeIcon icon='microchip' style={{ marginRight: '0.5em' }} />}
+        >
+          Inspect Device
+        </Button>,
+        <Tooltip title={artifactUnavailable ? 'Artifact unavailable for download' : ''}>
+          <Button
+            type='primary'
+            disabled={artifactUnavailable}
+            icon={<FontAwesomeIcon icon='download' style={{ marginRight: '0.5em' }} />}
+            href={artifactUrl}
+            download={fileName}
+          >
+            Artifact
+          </Button>
+        </Tooltip>
+      ]}
+    >
+      <Modal
+        title={`${props.device.type.name} Monitor`}
+        centered
+        visible={monitorOpen}
+        className={styles.modal}
+        width='70%'
+        footer={
+          <Button key='close' type='primary' onClick={() => setMonitorOpen(false)}>
+            Close
+          </Button>
           }
-          title={
-            <>
-              <Link to={`/device/${props.device.id}`}>
-                {props.device.type.name}
-              </Link>
-              <Tooltip title={`Device: ${props.device.id}`}>
-                <FontAwesomeIcon
-                  icon={'info-circle'}
-                  color={colors.info}
-                  style={{ marginLeft: '0.5em' }}
-                />
-              </Tooltip>
-            </>
+        onCancel={() => setMonitorOpen(false)}
+      >
+        <MonitoringTerminal deploymentId={props.id} deployStatus={props.status} deviceName={props.device.type.name} />
+      </Modal>
+      <Meta
+        style={{ flex: 'auto' }}
+        avatar={
+          <StatusTag status={props.status} addIcon />
           }
-          description={
-            showId ?
-              <Typography.Text style={{ color: 'rgba(0, 0, 0, 0.3)' }}>
+        title={
+          <>
+            <Link to={`/device/${props.device.id}`}>
+              {props.device.type.name}
+            </Link>
+            <Tooltip title={`Device: ${props.device.id}`}>
+              <FontAwesomeIcon
+                icon='info-circle'
+                color={colors.info}
+                style={{ marginLeft: '0.5em' }}
+              />
+            </Tooltip>
+          </>
+          }
+        description={
+            showId
+              ? <Typography.Text style={{ color: 'rgba(0, 0, 0, 0.3)' }}>
                 {props.id}
-              </Typography.Text>
-              :
-              <Typography.Link onClick={() => setShowId(true)}>
+                </Typography.Text>
+              : <Typography.Link onClick={() => setShowId(true)}>
                 Show Deployment Id
               </Typography.Link>
           }
-        />
-        {props.details && props.created && props.updated ?
-          <Row style={{ textAlign: 'center', justifyContent: 'center', flex: 'auto' }}>
-            <Col span={8}>
-              <div>
-                Created
-                <br/>
-                {dateFormatter(Date.parse(props.created.toString()))}
-              </div>
-            </Col>
-            <Col span={8}>
-              <div>
-                Last Update
-                <br/>
-                {dateFormatter(Date.parse(props.updated.toString()))}
-              </div>
-            </Col>
+      />
+      {props.details && (props.created != null) && (props.updated != null)
+        ? <Row style={{ textAlign: 'center', justifyContent: 'center', flex: 'auto' }}>
+          <Col span={8}>
+            <div>
+              Created
+              <br />
+              {dateFormatter(Date.parse(props.created.toString()))}
+            </div>
+          </Col>
+          <Col span={8}>
+            <div>
+              Last Update
+              <br />
+              {dateFormatter(Date.parse(props.updated.toString()))}
+            </div>
+          </Col>
           </Row>
-          :
-          undefined
-        }
-      </Item>
-    </CSSTransition>)
+        : undefined}
+    </Item>
+  )
 }

--- a/packages/deployment-server/src/util/app.ts
+++ b/packages/deployment-server/src/util/app.ts
@@ -38,11 +38,13 @@ export function createApp (db: PrismaClient): Application {
   })
 
   app.use(helmet({
+    crossOriginEmbedderPolicy: false,
     contentSecurityPolicy: {
       directives: {
         ...helmet.contentSecurityPolicy.getDefaultDirectives(),
         'script-src': ["'self'", "'unsafe-inline'"],
-        'img-src': ["'self'", 'data:', 'storage.googleapis.com', 'raw.githubusercontent.com']
+        'img-src': ["'self'", 'data:', 'storage.googleapis.com', 'raw.githubusercontent.com'],
+        'connect-src': ["'self'", 'data:', 'storage.googleapis.com']
       }
     }
   }))


### PR DESCRIPTION
## Changes Proposed:
<!-- Describe the changes to the code and functionality with this PR -->

- When using GCS as artifact/image store, we need to set the headers correctly.
- Remove the duplicate `CSSTransition`, which was added in the parent component

## How to Test PRs
1) First fetch the Pull-Request from the main repo, replacing `xx` with the ID of the PR:\
`git fetch git@github.com:eclipsesource/cdtcloud-deploymentserver.git pull/xx/head:pr_xx`
2) Checkout the Pull-Request, again replacing `xx` with the PR-ID:\
`git checkout pr_xx`
3) Perform the necessary tests for the PR